### PR TITLE
Sensible handling of boolean HTML attributes

### DIFF
--- a/lib/markaby/builder.rb
+++ b/lib/markaby/builder.rb
@@ -178,6 +178,13 @@ module Markaby
                 raise InvalidXhtmlError, "id `#{ele_id}' already used (id's must be unique)."
               end
             end
+            if AttrsBoolean.include? atname
+              if v
+                attrs[k] = atname.to_s
+              else
+                attrs.delete k
+              end
+            end
           end
         end
       end

--- a/lib/markaby/tags.rb
+++ b/lib/markaby/tags.rb
@@ -19,6 +19,13 @@ module Markaby
   AttrHAlign = [:align, :char, :charoff]
   AttrVAlign = [:valign]
   Attrs      = AttrCore + AttrI18n + AttrEvents
+  
+  AttrsBoolean = [
+    :checked, :disabled, :multiple, :readonly, :selected, # standard forms
+    :autofocus, :required, :novalidate, :formnovalidate, # HTML5 forms
+    :defer, :ismap, # <script defer>, <img ismap>
+    :compact, :declare, :noresize, :noshade, :nowrap # deprecated or unused
+  ]
 
   # All the tags and attributes from XHTML 1.0 Strict
   class XHTMLStrict


### PR DESCRIPTION
I think this fixes issue #22?

Basically, if the attribute is boolean, it discards the value given and always outputs correct XHTML. If the value given is not truthy, it removes the attribute from the element.

This way, you can just do `input.stuff! disabled:(something ? true : false)`.

A simple test to show you what it does:

```
puts [
    mab{ input disabled:'disabled' },
    mab{ input disabled:'banana' },
    mab{ input disabled:true },
    mab{ input disabled:42 },
    mab{ input disabled:false },

    mab{ input.banana! disabled:true },
    mab{ input.apple.banana! disabled:true },
    mab{ input.apple.banana! disabled:false },
]
```

Expected output: 

```
<input disabled="disabled"/>
<input disabled="disabled"/>
<input disabled="disabled"/>
<input disabled="disabled"/>
<input/>
<input id="banana" disabled="disabled" name="banana"/>
<input class="apple" id="banana" disabled="disabled" name="banana"/>
<input class="apple" id="banana" name="banana"/>
```

Output in current markaby:

```
<input disabled="disabled"/>
<input disabled="banana"/>
<input disabled="true"/>
<input disabled="42"/>
<input disabled="false"/>
<input id="banana" disabled="true" name="banana"/>
<input class="apple" id="banana" disabled="true" name="banana"/>
<input class="apple" id="banana" disabled="false" name="banana"/>
```

(This should probably be made into an unit test, but I couldn't get stuff to work.)
