### PR TITLE
Fix xhtml 1.1 errors

### DIFF
--- a/lib/markaby/tags.rb
+++ b/lib/markaby/tags.rb
@@ -65,7 +65,7 @@ module Markaby
       :head       => AttrI18n + [:id, :profile],
       :title      => AttrI18n + [:id],
       :base       => [:href, :id],
-      :meta       => AttrI18n + [:id, :http, :name, :content, :scheme, 'http-equiv'.intern],
+      :meta       => AttrI18n + [:id, :name, :content, :scheme, 'http-equiv'.intern],
       :link       => Attrs    + [:charset, :href, :hreflang, :type, :rel, :rev, :media],
       :style      => AttrI18n + [:id, :type, :media, :title, 'xml:space'.intern],
       :script     => [:id, :charset, :type, :src, :defer, 'xml:space'.intern],

--- a/lib/markaby/tags.rb
+++ b/lib/markaby/tags.rb
@@ -229,7 +229,6 @@ module Markaby
 
     @doctype = ['html']
     @tagset = XHTMLTransitional.tagset.merge({
-      :abbr => Attrs,
       :article => Attrs,
       :aside => Attrs,
       :audio => Attrs,

--- a/lib/markaby/tags.rb
+++ b/lib/markaby/tags.rb
@@ -112,7 +112,7 @@ module Markaby
       :img        => Attrs + [:src, :alt, :longdesc, :height, :width, :usemap, :ismap],
       :map        => AttrI18n + AttrEvents + [:id, :class, :style, :title, :name],
       :area       => Attrs + AttrFocus + [:shape, :coords, :href, :nohref, :alt],
-      :form       => Attrs + [:action, :method, :enctype, :onsubmit, :onreset, :accept, :accept],
+      :form       => Attrs + [:action, :method, :enctype, :onsubmit, :onreset, :accept, 'accept-charset'.intern],
       :label      => Attrs + [:for, :accesskey, :onfocus, :onblur],
       :input      => Attrs + AttrFocus + [:type, :name, :value, :checked, :disabled, :readonly, :size, :maxlength, :src, :alt, :usemap, :onselect, :onchange, :accept],
       :select     => Attrs + [:name, :size, :multiple, :disabled, :tabindex, :onfocus, :onblur, :onchange],

--- a/lib/markaby/tags.rb
+++ b/lib/markaby/tags.rb
@@ -229,6 +229,7 @@ module Markaby
 
     @doctype = ['html']
     @tagset = XHTMLTransitional.tagset.merge({
+      :abbr => Attrs,
       :article => Attrs,
       :aside => Attrs,
       :audio => Attrs,


### PR DESCRIPTION

THIS PR FIX XHTML 1.1 ERRORS

- @ form attributes : fix (typing?) error leading to double entry
    `... :accept, :accept]` replaced by `... :accept, 'accept-charset'.intern]`

- @ meta attributes : remove `:http` not in spec


