### PR TITLE
Fix compatibility with latest builder release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    builder (3.2.4)
+    builder (3.3.0)
     byebug (11.1.3)
     diff-lcs (1.5.0)
     json (2.6.3)

--- a/lib/markaby/builder.rb
+++ b/lib/markaby/builder.rb
@@ -245,7 +245,7 @@ module Markaby
   # is never used, though, and the stream stays intact.
   #
   # For a more practical explanation, check out the README.
-  class Fragment < ::Builder::BlankSlate
+  class Fragment < BasicObject
     def initialize(*args)
       @stream, @start, @length = args
       @transformed_stream = false


### PR DESCRIPTION
It removed `BlankSlate`. So, just use `BasicObject` which has been available for more than decade now.

This is already what was happening behind the scenes: https://github.com/rails/builder/pull/15/files#diff-94d48985e142bdb522d4d25ab7bf82493317da39f15f646feb04d6b9bc5ffb83L18

Note that I still have two test failures but they happen both with and without this change.